### PR TITLE
VKontakte API Added to the Social Media Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ latitude/longitude, and text search based upon categories, address, city, provin
 - [Twitter](https://dev.twitter.com/) - Enables an app to interact with most of Twitter’s functions.
 - [Tumblr](https://www.tumblr.com/docs/en/api/v2) - Create new ways to use Tumblr with access to content, likes, followers, and drafts.
 - [Vimeo](https://developer.vimeo.com/) - Access to Vimeo’s API.
+- [VK](https://vk.com/dev) - Access to VKontakte's API. This has a variety of features such as authorization via VK, embedding VK comments for things like blogs, and taking payments via VK. Additionally, you may use the VK API to control much of the functionality on the website (for example, adjusting shop inventory in your VK community's market section).
 - [Weibo](http://open.weibo.com/wiki/API%E6%96%87%E6%A1%A3/en) - Programmatic access to China’s most popular microblogging site.
 - [Whatsapp Document Interaction](https://www.whatsapp.com/faq/en/iphone/23559013) - If your application creates photos, videos or audio notes and you’d like your users to share these media using WhatsApp. #Limited
 - [Wordpress](https://codex.wordpress.org/WordPress_APIs) - Access to Wordpress’ API.


### PR DESCRIPTION
In the social media section, I have added a link to and description of the VKontakte official API.

For the uninitiated, VK is a competitor to Facebook, and is the largest social media platform in the Russian Federation, Ukraine, Belarus, and Kazakhstan.

Additionally, I'm not sure what title capitalization is preferred, so I just did Chicago.