### PR TITLE
Add Math section and Newton API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 - [Login and Authentication] (#login-authentication)
 - [Machine Learning] (#machine-learning)
 - [Maps] (#maps)
+- [Math] (#math)
 - [Miscellaneous] (#miscellaneous)
 - [Movies] (#movies)
 - [Music] (#music)
@@ -271,6 +272,9 @@ APIs
 - [Yahoo Maps](https://developer.yahoo.com/maps/) - Yahoo Maps lets you easily embed rich and interactive maps using your choice of platform.
 - [Yandex](https://tech.yandex.com/maps/) - API for installing Yandex.Maps and the necessary tools for working it on your web app or site.
 - [Daum Maps API](http://apis.map.daum.net/) - Daum Maps provide multiple APIs for Korean map.
+
+### Math
+- [Newton](https://newton.now.sh/) - An API for Arithmetic and Symbolic Math. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 
 
 ### Miscellaneous

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ APIs
 - [Daum Maps API](http://apis.map.daum.net/) - Daum Maps provide multiple APIs for Korean map.
 
 ### Math
-- [Newton](https://newton.now.sh/) - An API for Arithmetic and Symbolic Math. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 
+- [Newton](https://newton.now.sh/) - An API for Arithmetic and Symbolic Math. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 
 ### Miscellaneous
 


### PR DESCRIPTION
[Newton](https://newton.now.sh/) is a micro-service for performing arithmetic and symbolic math operations. 

I've created a Math section, because it is not accurately described as a science API and other math APIs can be added later.