### PR TITLE
Add TheAudioDB Music API

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ APIs
 - [Rhapsody](https://developer.rhapsody.com/) - Access metadata, user’s entire library of music and do much more.
 - [SoundCloud](https://developers.soundcloud.com) - Using the SoundCloud API, you can build applications that take sound on the web to the next level.
 - [Spotify](https://developer.spotify.com/web-api/) - Spotify’s Web API lets your applications fetch data from the Spotify music catalog and manage user’s playlists and saved music.
+- [TheAudioDB](http://www.theaudiodb.com) - Free JSON API for music data, artwork, charting, ratings and hashes. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 
 ### Music Analytics
 


### PR DESCRIPTION
![logo](https://cloud.githubusercontent.com/assets/1050512/24192426/d8f03852-0ee6-11e7-96c1-bea3ca1e3145.png)

TheAudioDB has a free JSON API, more details and instructions on [the forum here](http://www.theaudiodb.com/forum/viewtopic.php?f=6&t=8)

API is free to use, very simple and fast. Site is crowd sourced with 450,000 edits so far. Loads of audio data as well as artwork and charts including user ratings and user file hashes for identification. Test and production API key is available to use instantly.

**A few site stats**
Total Artists: 33,633
Albums: 160,298
Tracks: 2,010,170
File Hashes: 172,432

**Wrappers**
Dot.NET: https://github.com/BigGranu/TheAudioDB
JAVA: https://github.com/mozvip/theaudiodb-client