### PR TITLE
Update Twitch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ APIs
 - [Reddit](https://github.com/reddit/reddit/wiki/API) - API to build clients, crawlers, scrapers, and browser extensions. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 - [Snapchat](https://github.com/mgp25/SC-API) - PHP library of Snapchat’s private API. #Private
 - [Telegram](https://core.telegram.org/) - The Telegram API allows you to build your own customized Telegram clients.
-- [Twitch](https://github.com/justintv/Twitch-API) - The Twitch API enables you to develop your own applications using the rich feature set that Twitch provides.
+- [Twitch](https://dev.twitch.tv/docs) - The Twitch API enables you to develop your own applications using the rich feature set that Twitch provides.
 - [Twitter](https://dev.twitter.com/) - Enables an app to interact with most of Twitter’s functions.
 - [Tumblr](https://www.tumblr.com/docs/en/api/v2) - Create new ways to use Tumblr with access to content, likes, followers, and drafts.
 - [Vimeo](https://developer.vimeo.com/) - Access to Vimeo’s API.


### PR DESCRIPTION
> All documentation for the Twitch API has been moved to the [Twitch Developer Website](https://dev.twitch.tv/docs).