### PR TITLE
Add HERE Maps API

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ APIs
 - [Daum Maps API](http://apis.map.daum.net/) - Daum Maps provide multiple APIs for Korean map.
 - [DigitalGlobe](http://dgdev2016.wpengine.com/maps-api/) - DigitalGlobe Maps API delivers the world's best satellite imagery, straight to your app. #Beta
 - [Google Maps API](https://developers.google.com/maps/?hl=en) - Google Maps APIs are available for Android, iOS, web browsers and through HTTP web services. [Clients can be found here.](https://github.com/googlemaps/)
+- [HERE Maps API](https://developer.here.com/) - Wide range of APIs available through JavaScript, iOS, Android, or REST services.
 - [Leaflet.js](http://leafletjs.com/) - An open-source JavaScript library for mobile-friendly interactive maps. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 - [Mapbox](https://www.mapbox.com/developers/api/maps/) - Access to MapBox’s API.
 - [Naver Maps API](https://developers.naver.com/products/map) - Naver Maps provide multiple APIs for Korean map.


### PR DESCRIPTION
I thought worth adding the HERE Maps API, since:

 - there is a free plan which is not limited in time
 - the free plan includes quite some features (map tiles, geocoding, places, routing, etc.)

Source: https://developer.here.com/plans (choose "For the Public")

## Checklist

- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] Make an individual pull request for each suggestion.
- [x] Titles should be capitalized.
- [x] Keep descriptions short and simple.
- [x] End all descriptions with a full stop/period.
- [x] Check your spelling and grammar.
- [x] Make sure your text editor is set to remove trailing whitespace.
- [x] Try to make your Pull request and title as descriptive as possible.
- [x] Mark open source APIs with the open source icon
- [x] Mark all trial/demo based APIs with the 💸 emoticon.

