### PR TITLE
Update links to 404 urls in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ APIs
 
 - [Amazon Maps API v2](https://developer.amazon.com/maps) - Add interactive 3D maps, graphics, and custom overlays to your Fire Tablet and Fire phone apps.
 - [Bing Maps](https://www.microsoft.com/maps/choose-your-bing-maps-API.aspx) - Bing Maps platform provides multiple API options for your application.
-- [CartoDB](http://docs.carto.com/cartodb-platform/maps-api/) - Allows you to generate maps based on data hosted in your CartoDB account.
+- [CartoDB](https://carto.com/developers/#apis) - Allows you to generate maps based on data hosted in your CartoDB account.
 - [Daum Maps API](http://apis.map.daum.net/) - Daum Maps provide multiple APIs for Korean map.
 - [DigitalGlobe](http://dgdev2016.wpengine.com/maps-api/) - DigitalGlobe Maps API delivers the world's best satellite imagery, straight to your app. #Beta
 - [Google Maps API](https://developers.google.com/maps/?hl=en) - Google Maps APIs are available for Android, iOS, web browsers and through HTTP web services. [Clients can be found here.](https://github.com/googlemaps/)
@@ -406,7 +406,7 @@ APIs
 ### Music Discovery
 
 - [Rovi](https://developers.rovicorp.com/) - Access to Metadata, search capabilities and recommendations.
-- [Setlist.fm](http://api.setlist.fm/docs/index.html) - The setlist.fm API has been designed to give you easy access to setlist data in order to build fancy websites and other applications.
+- [Setlist.fm](https://api.setlist.fm/docs/1.0/index.html) - The setlist.fm API has been designed to give you easy access to setlist data in order to build fancy websites and other applications.
 - [TuneFind](http://www.tunefind.com/api) - Allows developers to enhance their services with song, show, and movie data from TuneFind.
 
 ### Music Identification


### PR DESCRIPTION
Update links to 2 sites that were 404ing. 

For CartoDB, I added link to the generic list of API's they have. 